### PR TITLE
README note about .env

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,15 @@ The goal of this web app is to provide functionality for public administrations 
 
 
 ## Installing the project
+
+Start by creating a copy of the template settings configuration from `backend/settings.env.template` and adding at least a `SECRET_KEY` variable (the others can be left blank for now).
+
+This can be temporarily activated in your environment, if your copy is called for example `.env`, using the command:
+
+```
+source .env
+```
+
 ### Dependencies (and virtual environment)
 Optionally, you can create a virtual python environment (venv), before starting
 the server:


### PR DESCRIPTION
Just a minor addition to the README repeating what the DEPLOY.md (which I saw post-factum) already says about creating a settings file. Without this the developer deployment is not possible. With it, I was happily able to get a full environment up and running.

The one thing that did not work is the demo data import, but I'm not going to raise a separate issue, just mention it in the channel.